### PR TITLE
fix: :zap: Improve setup.sh and enviroment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,11 +4,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - conda-forge::r-base=4.4.0
+  - conda-forge::r-base
   - conda-forge::r-essentials
   - conda-forge::libcurl
   - conda-forge::r-curl
-
-variables:
-  PKG_CONFIG_PATH: $CONDA_PREFIX/lib/pkgconfig
-  LD_LIBRARY_PATH: $CONDA_PREFIX/lib:$LD_LIBRARY_PATH

--- a/setup_conda-envs.sh
+++ b/setup_conda-envs.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+set -e  # Exit if any command fails
+
+# ─── FUNCTION TO PRINT ERRORS ────────────────────────────────────────────────
+error_exit() {
+    echo "Error: $1"
+    exit 1
+}
+
+# ─── CHECK IF CONDA IS AVAILABLE ─────────────────────────────────────────────
+if ! command -v conda &> /dev/null; then
+    error_exit "Conda is not installed or not available in the current session."
+fi
+
+# ─── PROMPT USER FOR ENVIRONMENT TYPE ────────────────────────────────────────
+echo "Do you want to configure a local or global Conda environment?"
+echo "1) Local (environment inside the project folder, e.g., .rhizosphere)"
+echo "2) Global (standard Conda environment, e.g., rhizosphere)"
+read -p "Enter choice [1/2]: " ENV_TYPE
+
+if [[ "$ENV_TYPE" == "1" ]]; then
+    ENV_PATH="$(pwd)/.rhizosphere"
+elif [[ "$ENV_TYPE" == "2" ]]; then
+    read -p "Enter the name of the global Conda environment: " ENV_NAME
+    ENV_PATH=$(conda info --envs | awk -v name="$ENV_NAME" '$1 == name {print $2}')
+    if [[ -z "$ENV_PATH" ]]; then
+        error_exit "The specified Conda environment '$ENV_NAME' was not found."
+    fi
+else
+    error_exit "Invalid choice. Please enter 1 for local or 2 for global."
+fi
+
+# ─── ENSURE THE SELECTED ENVIRONMENT EXISTS ──────────────────────────────────
+if [ ! -d "$ENV_PATH" ]; then
+    error_exit "The Conda environment at '$ENV_PATH' does not exist."
+fi
+
+echo "Configuring environment variables for Conda environment: $ENV_PATH"
+
+# ─── ENSURE ACTIVATION & DEACTIVATION DIRECTORIES EXIST ──────────────────────
+mkdir -p "$ENV_PATH/etc/conda/activate.d"
+mkdir -p "$ENV_PATH/etc/conda/deactivate.d"
+
+# ─── CREATE ACTIVATION SCRIPT ────────────────────────────────────────────────
+cat << EOF > "$ENV_PATH/etc/conda/activate.d/env_vars.sh"
+#!/bin/sh
+export PKG_CONFIG_PATH="$ENV_PATH/lib/pkgconfig"
+export LD_LIBRARY_PATH="$ENV_PATH/lib:\$LD_LIBRARY_PATH"
+EOF
+chmod +x "$ENV_PATH/etc/conda/activate.d/env_vars.sh"
+
+# ─── CREATE DEACTIVATION SCRIPT ──────────────────────────────────────────────
+cat << EOF > "$ENV_PATH/etc/conda/deactivate.d/env_vars.sh"
+#!/bin/sh
+unset PKG_CONFIG_PATH
+export LD_LIBRARY_PATH=\$(echo "\$LD_LIBRARY_PATH" | sed -e "s|$ENV_PATH/lib:||")
+EOF
+chmod +x "$ENV_PATH/etc/conda/deactivate.d/env_vars.sh"
+
+echo "Environment variables configured successfully! 🎉"
+echo "Restart your terminal or reactivate your Conda environment for changes to take effect."

--- a/test.sh
+++ b/test.sh
@@ -78,13 +78,6 @@ echo "1) Local environment (in project folder)"
 echo "2) Global environment (in Conda's envs directory)"
 read -p "Enter your choice [1/2]: " ENV_CHOICE
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-ENV_YML="$SCRIPT_DIR/environment.yml"
-
-if [ ! -f "$ENV_YML" ]; then
-    handle_error ${LINENO} "File '$ENV_YML' not found. Please create it with the desired configuration."
-fi
-
 case "$ENV_CHOICE" in
     1)
         # Config for local environment
@@ -169,12 +162,28 @@ EOF
         ;;
 esac
 
+# Mensaje final con instrucciones
+log_info "Environment setup completed."
+if [[ "$ENV_CHOICE" == "1" ]]; then
+    log_info "To activate this environment, run: conda activate $CONDA_ENV_PATH"
+else
+    log_info "To activate this environment, run: conda activate $ENV_NAME"
+fi
+
 # ─── RUN SETUP.R TO RESTORE R ENVIRONMENT ───────────────────────────────────────
 SETUP_R_SCRIPT="$SCRIPT_DIR/setup.R"
 
 if [ -f "$SETUP_R_SCRIPT" ]; then
     log_info "Running R setup script: $SETUP_R_SCRIPT"
-    Rscript "$SETUP_R_SCRIPT" || handle_error ${LINENO} "Error running $SETUP_R_SCRIPT"
+    
+    # Verify if Rscript is available
+    if ! command -v Rscript &> /dev/null; then
+        log_warning "Rscript not found. Please install R to run the setup script."
+    else
+        # Run the R script to restore the R environment
+        log_info "Running R setup script: $SETUP_R_SCRIPT"
+        Rscript "$SETUP_R_SCRIPT" || handle_error ${LINENO} "Error running $SETUP_R_SCRIPT"
+    fi
 else
     log_warning "No '$SETUP_R_SCRIPT' found. Skipping R environment setup."
 fi


### PR DESCRIPTION
Users can now choose between local (project folder) or global (Conda envs)  environment installation via interactive prompt. Includes proper path  handling and activation scripts for both options.